### PR TITLE
Refactor patch persistence

### DIFF
--- a/src/layouts/WorkSpace.vue
+++ b/src/layouts/WorkSpace.vue
@@ -139,23 +139,22 @@ const removeModule = (id) => {
     bus.clearModule(id);
 }
 
-// Save patch to localStorage
+// Save patch using SynthBus store
 const save = () => {
-    const serialized = modules.value.map((mod) => ({
-        id: mod.id,
-        type: mod.type,
-        position: mod.position,
-    }))
-    localStorage.setItem('synth-patch', JSON.stringify(serialized))
+    bus.savePatch(
+        modules.value.map((mod) => ({
+            id: mod.id,
+            type: mod.type,
+            position: mod.position,
+        }))
+    )
     alert('Patch saved.')
 }
 
-// Load patch from localStorage
+// Load patch using SynthBus store
 const load = () => {
-    const patch = localStorage.getItem('synth-patch')
-    if (!patch) return alert('No saved patch found.')
-
-    const loadedModules = JSON.parse(patch)
+    const loadedModules = bus.loadPatch()
+    if (!loadedModules.length) return alert('No saved patch found.')
 
     // Reset current bus state and modules before rehydrating
     bus.clear()
@@ -172,7 +171,7 @@ const clear = () => {
     if (confirm('Clear all modules and connections?')) {
         modules.value = []
         bus.clear()
-        localStorage.removeItem('synth-patch')
+        bus.clearPatch()
     }
 }
 

--- a/src/stores/index.js
+++ b/src/stores/index.js
@@ -60,6 +60,11 @@ export const useSynthBus = defineStore('synthBus', () => {
     return []
   }
 
+  const clearPatch = () => {
+    savedModules.value = []
+    localStorage.removeItem('synth-patch')
+  }
+
   return {
     inputs,
     outputs,
@@ -71,6 +76,7 @@ export const useSynthBus = defineStore('synthBus', () => {
     savedModules,
     savePatch,
     loadPatch,
+    clearPatch,
     addConnection,
     removeConnection,
   }


### PR DESCRIPTION
## Summary
- add `clearPatch` helper in store to handle persistence cleanup
- save/load/clear workspace patches via store instead of direct localStorage access

## Testing
- `yarn build` *(fails: package not present in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_686a75e17bd083269c4c884cfb131d02