### PR TITLE
Add vitest test suite for SynthBus store

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
         "build": "vite build",
         "preview": "vite preview",
         "format": "prettier --write .",
-        "lint": "prettier --check ."
+        "lint": "prettier --check .",
+        "test": "vitest run"
     },
     "dependencies": {
         "nanoid": "^5.1.5",
@@ -19,6 +20,7 @@
         "@tailwindcss/vite": "^4.1.8",
         "prettier": "^3.5.3",
         "tailwindcss": "^4.1.10",
-        "vite": "^6.3.5"
+        "vite": "^6.3.5",
+        "vitest": "^1.5.0"
     }
 }

--- a/tests/store.spec.js
+++ b/tests/store.spec.js
@@ -1,0 +1,48 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { useSynthBus } from '../src/stores'
+
+// simple localStorage mock for vitest node environment
+const mockStorage = () => {
+  let store = {}
+  return {
+    getItem: (k) => (k in store ? store[k] : null),
+    setItem: (k, v) => { store[k] = v },
+    removeItem: (k) => { delete store[k] },
+    clear: () => { store = {} }
+  }
+}
+
+describe('synth bus store', () => {
+  let bus
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    bus = useSynthBus()
+    // reset mock localStorage
+    Object.defineProperty(global, 'localStorage', {
+      value: mockStorage(),
+      configurable: true
+    })
+  })
+
+  it('adds connections without duplicates', () => {
+    bus.addConnection({ from: 'a', to: 'b' })
+    bus.addConnection({ from: 'a', to: 'b' })
+    expect(bus.connections.length).toBe(1)
+  })
+
+  it('removing a module clears its connections', () => {
+    bus.addConnection({ from: 'mod1', to: 'mod2' })
+    bus.addConnection({ from: 'mod2', to: 'mod1' })
+    bus.clearModule('mod1')
+    expect(bus.connections.some(c => c.from === 'mod1' || c.to === 'mod1')).toBe(false)
+  })
+
+  it('savePatch and loadPatch persist modules', () => {
+    const mods = [{ id: 'osc-1', type: 'osc', position: { x: 1, y: 1 } }]
+    bus.savePatch(mods)
+    setActivePinia(createPinia())
+    const another = useSynthBus()
+    expect(another.loadPatch()).toEqual(mods)
+  })
+})


### PR DESCRIPTION
## Summary
- add vitest to devDependencies and provide `npm test` script
- create test suite covering connections, module removal, and patch persistence

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a7721a4a083269ffecfcc3db7a435