### PR TITLE
Add LFO module and improved patch management

### DIFF
--- a/src/components/LFOModule.vue
+++ b/src/components/LFOModule.vue
@@ -1,0 +1,73 @@
+<template>
+    <div class="bg-gray-800 text-white p-4 rounded-2xl shadow-md w-full max-w-sm">
+        <h2 class="text-xl font-semibold mb-4">LFO {{ label }}</h2>
+        <div class="mb-3">
+            <label class="block text-sm font-medium mb-1">Frequency (Hz)</label>
+            <input
+                type="range"
+                min="0.1"
+                max="20"
+                step="0.1"
+                v-model="frequency"
+                @input="updateFrequency"
+                class="w-full accent-green-500"
+            />
+            <div class="text-xs text-gray-300 mt-1">{{ frequency }} Hz</div>
+        </div>
+        <div class="mb-3">
+            <label class="block text-sm font-medium mb-1">Waveform</label>
+            <select v-model="waveform" @change="updateWaveform" class="w-full bg-gray-700 text-white rounded-md px-2 py-1">
+                <option value="sine">Sine</option>
+                <option value="square">Square</option>
+                <option value="triangle">Triangle</option>
+                <option value="sawtooth">Sawtooth</option>
+            </select>
+        </div>
+    </div>
+</template>
+
+<script setup>
+import { ref, onMounted } from 'vue'
+import { useSynthEngine } from '../composable/useSynthEngine'
+
+const props = defineProps({
+    label: {
+        type: String,
+        default: 'A'
+    }
+})
+
+const emit = defineEmits(['ready'])
+
+const frequency = ref(2)
+const waveform = ref('sine')
+
+const { context, createOscillatorNode } = useSynthEngine()
+
+const oscRef = ref(null)
+const gainRef = ref(null)
+
+onMounted(() => {
+    const { osc, gain } = createOscillatorNode({
+        frequency: frequency.value,
+        type: waveform.value,
+        gain: 1
+    })
+    oscRef.value = osc
+    gainRef.value = gain
+
+    emit('ready', {
+        output: gain,
+        input: null,
+        id: `lfo-${props.label}`
+    })
+})
+
+const updateFrequency = () => {
+    oscRef.value.frequency.setValueAtTime(frequency.value, context.currentTime)
+}
+
+const updateWaveform = () => {
+    oscRef.value.type = waveform.value
+}
+</script>

--- a/src/components/ModuleWrapper.vue
+++ b/src/components/ModuleWrapper.vue
@@ -45,6 +45,7 @@ import OscillatorModule from './OscillatorModule.vue'
 import FilterModule from './FilterModule.vue'
 import EnvelopeModule from './EnvelopeModule.vue'
 import MasterOutput from './MasterOutput.vue'
+import LFOModule from './LFOModule.vue'
 
 import { useSynthBus } from '../stores/index'
 const bus = useSynthBus()
@@ -56,6 +57,7 @@ const componentMap = {
     Filter: FilterModule,
     Envelope: EnvelopeModule,
     Master: MasterOutput,
+    LFO: LFOModule,
 }
 
 const moduleComponent = computed(() => componentMap[props.module.type]);

--- a/src/components/base/SideBar.vue
+++ b/src/components/base/SideBar.vue
@@ -13,5 +13,5 @@
 </template>
 
 <script setup>
-const moduleTypes = ['Oscillator', 'Filter', 'Envelope', 'Master']
+const moduleTypes = ['Oscillator', 'Filter', 'Envelope', 'Master', 'LFO']
 </script>

--- a/src/stores/index.js
+++ b/src/stores/index.js
@@ -6,6 +6,7 @@ export const useSynthBus = defineStore('synthBus', () => {
   const outputs = ref([])
   const triggers = ref({})
   const savedModules = ref([])
+  const patchLibrary = ref({})
   const connections = ref([]);
 
   const addConnection = (conn) => {
@@ -46,23 +47,38 @@ export const useSynthBus = defineStore('synthBus', () => {
 
   }
 
-  const savePatch = (modules) => {
-    savedModules.value = JSON.parse(JSON.stringify(modules))
-    localStorage.setItem('synth-patch', JSON.stringify(savedModules.value))
+  const savePatch = (modules, name = 'default') => {
+    const library = JSON.parse(localStorage.getItem('synth-patches') || '{}')
+    library[name] = JSON.parse(JSON.stringify(modules))
+    patchLibrary.value = library
+    savedModules.value = library[name]
+    localStorage.setItem('synth-patches', JSON.stringify(library))
   }
 
-  const loadPatch = () => {
-    const stored = localStorage.getItem('synth-patch')
-    if (stored) {
-      savedModules.value = JSON.parse(stored)
-      return savedModules.value
-    }
-    return []
+  const loadPatch = (name = 'default') => {
+    const library = JSON.parse(localStorage.getItem('synth-patches') || '{}')
+    patchLibrary.value = library
+    savedModules.value = library[name] || []
+    return savedModules.value
+  }
+
+  const listPatches = () => {
+    const library = JSON.parse(localStorage.getItem('synth-patches') || '{}')
+    patchLibrary.value = library
+    return Object.keys(library)
+  }
+
+  const removePatch = (name) => {
+    const library = JSON.parse(localStorage.getItem('synth-patches') || '{}')
+    delete library[name]
+    patchLibrary.value = library
+    localStorage.setItem('synth-patches', JSON.stringify(library))
   }
 
   const clearPatch = () => {
     savedModules.value = []
-    localStorage.removeItem('synth-patch')
+    patchLibrary.value = {}
+    localStorage.removeItem('synth-patches')
   }
 
   return {
@@ -74,8 +90,11 @@ export const useSynthBus = defineStore('synthBus', () => {
     clearModule,
     connections,
     savedModules,
+    patchLibrary,
     savePatch,
     loadPatch,
+    listPatches,
+    removePatch,
     clearPatch,
     addConnection,
     removeConnection,

--- a/tests/store.spec.js
+++ b/tests/store.spec.js
@@ -45,4 +45,15 @@ describe('synth bus store', () => {
     const another = useSynthBus()
     expect(another.loadPatch()).toEqual(mods)
   })
+
+  it('handles multiple named patches', () => {
+    const a = [{ id: 'a', type: 'osc', position: { x: 0, y: 0 } }]
+    const b = [{ id: 'b', type: 'filter', position: { x: 1, y: 1 } }]
+    bus.savePatch(a, 'first')
+    bus.savePatch(b, 'second')
+    expect(bus.listPatches().sort()).toEqual(['first', 'second'])
+    expect(bus.loadPatch('second')).toEqual(b)
+    bus.removePatch('first')
+    expect(bus.listPatches()).toEqual(['second'])
+  })
 })


### PR DESCRIPTION
## Summary
- introduce an `LFOModule` component
- register `LFO` in `ModuleWrapper` and sidebar menu
- extend store with named patch saving/loading and management
- update unit tests for new store behaviour

## Testing
- `yarn lint` *(fails: package not in lockfile)*
- `yarn install --immutable` *(fails: network access blocked)*
- `yarn test` *(fails: package not in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_686a7d6345808326a14e95b148b0bbbf