### PR TITLE
Add delay and reverb modules

### DIFF
--- a/src/components/DelayModule.vue
+++ b/src/components/DelayModule.vue
@@ -1,0 +1,65 @@
+<template>
+    <div class="bg-gray-800 p-4 rounded-md shadow text-white w-72">
+        <h2 class="text-lg font-semibold mb-3">⏱️ Delay</h2>
+        <div class="mb-3">
+            <label class="block text-xs">Time (s)</label>
+            <input type="range" min="0" max="1" step="0.01" v-model="time" @input="updateTime" class="w-full" />
+        </div>
+        <div class="mb-3">
+            <label class="block text-xs">Feedback</label>
+            <input type="range" min="0" max="0.95" step="0.01" v-model="feedback" @input="updateFeedback" class="w-full" />
+        </div>
+        <div class="mb-3">
+            <label class="block text-xs">Mix</label>
+            <input type="range" min="0" max="1" step="0.01" v-model="mix" @input="updateMix" class="w-full" />
+        </div>
+    </div>
+</template>
+
+<script setup>
+import { ref, onMounted } from 'vue'
+import { useSynthEngine } from '../composable/useSynthEngine'
+
+const emit = defineEmits(['ready'])
+const { context } = useSynthEngine()
+
+const inputGain = context.createGain()
+const delay = context.createDelay(1.0)
+const feedbackGain = context.createGain()
+const dryGain = context.createGain()
+const wetGain = context.createGain()
+const outputGain = context.createGain()
+
+inputGain.connect(delay)
+inputGain.connect(dryGain)
+
+delay.connect(feedbackGain).connect(delay)
+delay.connect(wetGain)
+
+dryGain.connect(outputGain)
+wetGain.connect(outputGain)
+
+const time = ref(0.3)
+const feedback = ref(0.3)
+const mix = ref(0.5)
+
+delay.delayTime.value = time.value
+feedbackGain.gain.value = feedback.value
+wetGain.gain.value = mix.value
+dryGain.gain.value = 1 - mix.value
+
+onMounted(() => {
+    emit('ready', {
+        id: 'delay-' + Math.random().toString(36).substring(7),
+        input: inputGain,
+        output: outputGain,
+    })
+})
+
+const updateTime = () => delay.delayTime.setValueAtTime(time.value, context.currentTime)
+const updateFeedback = () => feedbackGain.gain.setTargetAtTime(feedback.value, context.currentTime, 0.01)
+const updateMix = () => {
+    wetGain.gain.setTargetAtTime(mix.value, context.currentTime, 0.01)
+    dryGain.gain.setTargetAtTime(1 - mix.value, context.currentTime, 0.01)
+}
+</script>

--- a/src/components/ModuleWrapper.vue
+++ b/src/components/ModuleWrapper.vue
@@ -46,6 +46,8 @@ import FilterModule from './FilterModule.vue'
 import EnvelopeModule from './EnvelopeModule.vue'
 import MasterOutput from './MasterOutput.vue'
 import LFOModule from './LFOModule.vue'
+import DelayModule from './DelayModule.vue'
+import ReverbModule from './ReverbModule.vue'
 
 import { useSynthBus } from '../stores/index'
 const bus = useSynthBus()
@@ -58,6 +60,8 @@ const componentMap = {
     Envelope: EnvelopeModule,
     Master: MasterOutput,
     LFO: LFOModule,
+    Delay: DelayModule,
+    Reverb: ReverbModule,
 }
 
 const moduleComponent = computed(() => componentMap[props.module.type]);

--- a/src/components/ReverbModule.vue
+++ b/src/components/ReverbModule.vue
@@ -1,0 +1,70 @@
+<template>
+    <div class="bg-gray-800 p-4 rounded-md shadow text-white w-72">
+        <h2 class="text-lg font-semibold mb-3">🏟️ Reverb</h2>
+        <div class="mb-3">
+            <label class="block text-xs">Decay (s)</label>
+            <input type="range" min="0.1" max="5" step="0.1" v-model="decay" @input="updateImpulse" class="w-full" />
+        </div>
+        <div class="mb-3">
+            <label class="block text-xs">Mix</label>
+            <input type="range" min="0" max="1" step="0.01" v-model="mix" @input="updateMix" class="w-full" />
+        </div>
+    </div>
+</template>
+
+<script setup>
+import { ref, onMounted } from 'vue'
+import { useSynthEngine } from '../composable/useSynthEngine'
+
+const emit = defineEmits(['ready'])
+const { context } = useSynthEngine()
+
+const inputGain = context.createGain()
+const convolver = context.createConvolver()
+const dryGain = context.createGain()
+const wetGain = context.createGain()
+const outputGain = context.createGain()
+
+inputGain.connect(convolver)
+inputGain.connect(dryGain)
+convolver.connect(wetGain)
+dryGain.connect(outputGain)
+wetGain.connect(outputGain)
+
+const decay = ref(2)
+const mix = ref(0.5)
+
+const createImpulse = (time) => {
+    const rate = context.sampleRate
+    const length = rate * time
+    const impulse = context.createBuffer(2, length, rate)
+    for (let ch = 0; ch < 2; ch++) {
+        const buf = impulse.getChannelData(ch)
+        for (let i = 0; i < length; i++) {
+            buf[i] = (Math.random() * 2 - 1) * Math.pow(1 - i / length, time)
+        }
+    }
+    return impulse
+}
+
+convolver.buffer = createImpulse(decay.value)
+wetGain.gain.value = mix.value
+dryGain.gain.value = 1 - mix.value
+
+onMounted(() => {
+    emit('ready', {
+        id: 'reverb-' + Math.random().toString(36).substring(7),
+        input: inputGain,
+        output: outputGain,
+    })
+})
+
+const updateImpulse = () => {
+    convolver.buffer = createImpulse(decay.value)
+}
+
+const updateMix = () => {
+    wetGain.gain.setTargetAtTime(mix.value, context.currentTime, 0.01)
+    dryGain.gain.setTargetAtTime(1 - mix.value, context.currentTime, 0.01)
+}
+</script>

--- a/src/components/base/SideBar.vue
+++ b/src/components/base/SideBar.vue
@@ -13,5 +13,5 @@
 </template>
 
 <script setup>
-const moduleTypes = ['Oscillator', 'Filter', 'Envelope', 'Master', 'LFO']
+const moduleTypes = ['Oscillator', 'Filter', 'Envelope', 'Master', 'LFO', 'Delay', 'Reverb']
 </script>


### PR DESCRIPTION
## Summary
- add `DelayModule.vue`
- add `ReverbModule.vue`
- register new modules in `ModuleWrapper.vue`
- expose Delay and Reverb in the sidebar

## Testing
- `yarn format` *(fails: package missing from lockfile)*
- `yarn lint` *(fails: package missing from lockfile)*
- `yarn test` *(fails: package missing from lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_686a84c88bb48326a056b46b9fe43283