### PR TITLE
Add color-coded patch matrix

### DIFF
--- a/src/components/PatchMatrix.vue
+++ b/src/components/PatchMatrix.vue
@@ -24,14 +24,14 @@
                 >
                     <button
                         :class="[
-                        'w-5 h-5 rounded-full transition',
-                        isConnected(output.id, input.id)
-                             ? 'bg-green-500 hover:bg-red-500'
-                             : 'bg-gray-700 hover:bg-green-500'
+                            'w-5 h-5 rounded-full transition',
+                            isConnected(output.id, input.id)
+                                ? `${getSignalColorClass(output.id)} hover:bg-red-500`
+                                : 'bg-gray-700 hover:bg-green-500'
                         ]"
                         :title="isConnected(output.id, input.id)
-                        ? `Unpatch ${output.label} → ${input.label}`
-                        : `Patch ${output.label} → ${input.label}`"
+                            ? `Unpatch ${output.label} → ${input.label}`
+                            : `Patch ${output.label} → ${input.label}`"
                         @click="togglePatch(output.id, input.id)"
                     />
                 </td>
@@ -44,6 +44,7 @@
 <script setup>
 import { computed } from 'vue'
 import { useSynthBus } from '../stores/index'
+import { getSignalColorClass } from '../utils/signalColors'
 
 const bus = useSynthBus()
 const inputs = computed(() => bus.inputs)

--- a/src/utils/signalColors.js
+++ b/src/utils/signalColors.js
@@ -1,0 +1,12 @@
+export const signalColors = {
+    osc: 'bg-blue-500',
+    filter: 'bg-orange-500',
+    env: 'bg-purple-500',
+    lfo: 'bg-teal-500',
+    master: 'bg-yellow-500',
+}
+
+export const getSignalColorClass = (id) => {
+    const key = id.split('-')[0]
+    return signalColors[key] || 'bg-green-500'
+}


### PR DESCRIPTION
## Summary
- map module IDs to colors
- color-code connections in the patch matrix

## Testing
- `yarn lint` *(fails: This package doesn't seem to be present in your lockfile)*
- `yarn test` *(fails: This package doesn't seem to be present in your lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_686a8523d66c83268a4e3162d95f447a