### PR TITLE
Fix cable display relative to workspace

### DIFF
--- a/src/components/PatchMatrix.vue
+++ b/src/components/PatchMatrix.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="overflow-auto max-w-full max-h-[60vh] bg-gray-900 text-green-200 rounded-md shadow border border-gray-700 p-4">
+    <div class="overflow-auto max-w-full max-h-[60vh] bg-gray-900 text-green-200 rounded-md shadow border border-gray-700 p-4 relative z-20">
         <h2 class="text-lg font-semibold mb-4 module-title">🎛️ Patch Matrix</h2>
         <table class="table-auto border-collapse text-sm">
             <thead>

--- a/src/layouts/WorkSpace.vue
+++ b/src/layouts/WorkSpace.vue
@@ -12,7 +12,7 @@
             <Topbar :patchCount="modules.length" />
 
             <!-- Workspace Area -->
-            <div class="p-4 h-full overflow-auto relative">
+            <div class="p-4 h-full overflow-auto relative" ref="workspaceRef">
                 <ModuleWrapper
                     v-for="mod in modules"
                     :key="mod.id"
@@ -91,6 +91,7 @@ import VirtualKeyboard from '../components/VirtualKeyboard.vue'
 
 const {resume} = useSynthEngine()
 const bus = useSynthBus()
+const workspaceRef = ref(null)
 const moduleRefs = ref({})
 const modules = ref([]) // All spawned modules
 const connections = computed(() => bus.connections)
@@ -116,9 +117,17 @@ const resumeAudio = async () => {
 
 const getSocketPosition = el => {
     const rect = el.getBoundingClientRect()
+    const container = workspaceRef.value
+    if (container) {
+        const cRect = container.getBoundingClientRect()
+        return {
+            x: rect.left + rect.width / 2 - cRect.left + container.scrollLeft,
+            y: rect.top + rect.height / 2 - cRect.top + container.scrollTop,
+        }
+    }
     return {
-        x: rect.left + rect.width / 2 + window.scrollX,
-        y: rect.top + rect.height / 2 + window.scrollY,
+        x: rect.left + rect.width / 2,
+        y: rect.top + rect.height / 2,
     }
 }
 


### PR DESCRIPTION
## Summary
- align cable coordinates with workspace
- keep patch matrix above modules

## Testing
- `yarn lint` *(fails: This package doesn't seem to be present in your lockfile)*
- `yarn test` *(fails: This package doesn't seem to be present in your lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_686a8e9c64688326b33f30c3e1acb8b5