### PR TITLE
Fix Patch Matrix Position and Layering

### DIFF
--- a/src/components/ModuleWrapper.vue
+++ b/src/components/ModuleWrapper.vue
@@ -1,6 +1,6 @@
 <template>
     <div
-        class="absolute select-none"
+        class="absolute select-none z-10"
         :style="`left: ${position.x}px; top: ${position.y}px;`"
     >
         <div class="module-header" @mousedown.prevent="startDrag">

--- a/src/components/PatchMatrix.vue
+++ b/src/components/PatchMatrix.vue
@@ -1,5 +1,7 @@
 <template>
-    <div class="overflow-auto max-w-full max-h-[60vh] bg-gray-900 text-green-200 rounded-md shadow border border-gray-700 p-4 relative z-20">
+    <div
+        class="absolute bottom-4 right-4 overflow-auto max-w-full max-h-[60vh] bg-gray-900 text-green-200 rounded-md shadow border border-gray-700 p-4 z-0"
+    >
         <h2 class="text-lg font-semibold mb-4 module-title">🎛️ Patch Matrix</h2>
         <table class="table-auto border-collapse text-sm">
             <thead>


### PR DESCRIPTION
## Summary
- position the Patch Matrix at the bottom-right of the workspace
- give ModuleWrapper a z-index so modules stay above the matrix
