### PR TITLE
Fix master output cleanup

### DIFF
--- a/src/components/MasterOutput.vue
+++ b/src/components/MasterOutput.vue
@@ -149,6 +149,9 @@ onMounted(() => {
 
 onUnmounted(() => {
     if (animationFrame) cancelAnimationFrame(animationFrame)
+    inputGain.disconnect()
+    masterGain.disconnect()
+    analyser.disconnect()
 })
 
 const getMeterColor = (value) => {


### PR DESCRIPTION
## Summary
- disconnect `inputGain`, `masterGain` and `analyser` nodes when `MasterOutput` unmounts

## Testing
- `npm test` *(fails: `vitest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ad7488d0083268f89fa0579e746b3