### PR TITLE
Fix cable rendering

### DIFF
--- a/src/components/ModuleWrapper.vue
+++ b/src/components/ModuleWrapper.vue
@@ -69,7 +69,8 @@ const inputRef = ref(null)
 
 defineExpose({outputRef, inputRef})
 const handleReady = data => {
-    bus.register(data)
+    // Use wrapper id for consistent referencing across UI and store
+    bus.register({ ...data, id: props.module.id })
 }
 
 const remove = () => {


### PR DESCRIPTION
## Summary
- use wrapper module id when registering with SynthBus

## Testing
- `yarn lint` *(fails: package not present in lockfile)*
- `yarn test` *(fails: package not present in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_686adf103c008326bcdaeafff3f64826